### PR TITLE
Story Card Profile Ternary

### DIFF
--- a/src/app/profile/[userId]/page.js
+++ b/src/app/profile/[userId]/page.js
@@ -12,7 +12,6 @@ function UserDashboard({ params }) {
 
   const getUserStories = () => {
     getUser(userId).then((data) => {
-      console.warn(data);
       setUserStories(data);
     });
   };

--- a/src/components/StoryCard.js
+++ b/src/components/StoryCard.js
@@ -19,8 +19,6 @@ function StoryCard({ storyObj, onUpdate }) {
   const { user } = useAuth();
   const pathname = usePathname();
   const profilePage = pathname === `/profile/${user.id}`;
-  console.warn(profilePage);
-  console.warn(profilePage);
 
   return (
     <Card className="card" style={{ width: '18rem', margin: '10px' }}>

--- a/src/components/StoryCard.js
+++ b/src/components/StoryCard.js
@@ -5,16 +5,22 @@ import PropTypes from 'prop-types';
 import Card from 'react-bootstrap/Card';
 import Link from 'next/link';
 import { Button } from 'react-bootstrap';
+import { usePathname } from 'next/navigation';
 import { deleteStory } from '../api/storyData';
+import { useAuth } from '../utils/context/authContext';
 
 function StoryCard({ storyObj, onUpdate }) {
-  // FOR DELETE, WE NEED TO REMOVE THE BOOK AND HAVE THE VIEW RERENDER,
-  // SO WE PASS THE FUNCTION FROM THE PARENT THAT GETS THE BOOKS
   const deleteThisStory = () => {
     if (window.confirm(`Delete ${storyObj.title}?`)) {
       deleteStory(storyObj.id).then(() => onUpdate());
     }
   };
+
+  const { user } = useAuth();
+  const pathname = usePathname();
+  const profilePage = pathname === `/profile/${user.id}`;
+  console.warn(profilePage);
+  console.warn(profilePage);
 
   return (
     <Card className="card" style={{ width: '18rem', margin: '10px' }}>
@@ -25,17 +31,21 @@ function StoryCard({ storyObj, onUpdate }) {
         <h6>Target Audience: {storyObj.targetAudience}</h6>
         <small>Date Created: {new Date(storyObj.dateCreated).toLocaleDateString()}</small>
         <div className="d-flex justify-content-between mt-3">
-          <Link href={`/stories/${storyObj.id}/edit`} passHref>
-            <Button variant="info">Edit</Button>
-          </Link>
           <Link href={`/stories/${storyObj.id}`} passHref>
             <Button variant="dark" title="View Details">
               View
             </Button>
           </Link>
-          <Button variant="danger" onClick={deleteThisStory}>
-            Delete
-          </Button>
+          {profilePage ? (
+            <>
+              <Link href={`/stories/${storyObj.id}/edit`} passHref>
+                <Button variant="info">Edit</Button>
+              </Link>
+              <Button variant="danger" onClick={deleteThisStory}>
+                Delete
+              </Button>
+            </>
+          ) : null}
         </div>
       </Card.Body>
     </Card>


### PR DESCRIPTION
## Detailed Description
<!--- Explain **what** was changed and **why** -->
- Added a ternary to the story card, so that the crud buttons only appear if the user is on the profile page.
- Moved the "View" button so that it would still show regardless of the route.

## How to Test
<!--- Step-by-step instructions for testing your changes. -->
<!--- Include any necessary setup steps, commands to run, or test cases. -->
1. Log in as a user
2. Verify that the "View" button is visible in the story cards on the home page.
3. Navigate to the profile page (/profile/{user.id}) by clicking the "Profile" button in the navbar
4. Verify that the "Edit" and "Delete" buttons appear on the StoryCard for stories owned by the logged-in user.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change is necessary to ensure that only users viewing their own profile can see the edit and delete options, and therefore preventing anyone else from making changes to the users stories.

## Types of Changes
<!--- What type of changes are introduced? Put an `x` in all the boxes that apply: -->
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 💡 Improvement
- [ ] ⚠️ Breaking change
- [ ] 🧹 Code cleanup
- [ ] 📖 Documentation