### PR TITLE
Categories clickable

### DIFF
--- a/src/api/categoryData.js
+++ b/src/api/categoryData.js
@@ -17,17 +17,21 @@ const getCategories = () =>
   });
 
 // Get Stories by Category
-// const getStoriesByCategory = () =>
-//   new Promise((resolve, reject) => {
-//     fetch(`${endpoint}/stories/categories/${categoryId}`, {
-//       method: 'GET',
-//       headers: {
-//         'Content-Type': 'application/json',
-//       },
-//     })
-//       .then((response) => response.json())
-//       .then((data) => resolve(Object.values(data)))
-//       .catch(reject);
-//   });
+const getStoriesByCategory = (categoryId) =>
+  new Promise((resolve, reject) => {
+    fetch(`${endpoint}/stories/categories/${categoryId}`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })
+      .then((response) => response.json())
+      .then((data) => resolve(Object.values(data)))
+      .catch(reject);
+  });
 
-export default getCategories;
+const trash = () => {
+  console.warn('delete me');
+};
+
+export { getCategories, getStoriesByCategory, trash };

--- a/src/app/categories/[categoryId]/page.js
+++ b/src/app/categories/[categoryId]/page.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function page() {
+  return <div>test</div>;
+}

--- a/src/app/categories/[categoryId]/page.js
+++ b/src/app/categories/[categoryId]/page.js
@@ -1,5 +1,36 @@
-import React from 'react';
+'use client';
 
-export default function page() {
-  return <div>test</div>;
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import { getStoriesByCategory } from '../../../api/categoryData';
+import StoryCard from '../../../components/StoryCard';
+
+export default function CategoryStories({ params }) {
+  const [catStories, setCatStories] = useState([]);
+
+  const { categoryId } = params;
+
+  const getCatStories = () => {
+    getStoriesByCategory(categoryId).then((data) => {
+      setCatStories(data);
+    });
+  };
+
+  useEffect(() => {
+    getCatStories();
+  }, []);
+
+  return (
+    <div className="d-flex flex-wrap justify-content-center">
+      {catStories.map((story) => (
+        <StoryCard key={story.id} storyObj={story} onUpdate={getCatStories} />
+      ))}
+    </div>
+  );
 }
+
+CategoryStories.propTypes = {
+  params: PropTypes.shape({
+    categoryId: PropTypes.number.isRequired,
+  }).isRequired,
+};

--- a/src/app/categories/page.js
+++ b/src/app/categories/page.js
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState, useEffect } from 'react';
-import getCategories from '../../api/categoryData';
+import { getCategories } from '../../api/categoryData';
 import CategoryCard from '../../components/Category';
 
 function CategoriesPage() {

--- a/src/components/Category.js
+++ b/src/components/Category.js
@@ -1,10 +1,19 @@
 import PropTypes from 'prop-types';
+import { Button } from 'react-bootstrap';
 import Card from 'react-bootstrap/Card';
+// import { useRouter } from 'next/navigation';
 
 function CategoryCard({ categoryObj }) {
+  //  const router = useRouter();
+
+  // const handleCategoryClick = (categoryId) => {
+  //   router.push(`/categories/${categoryId}`);
+  // };
+
   return (
     <Card>
       <Card.Body>{categoryObj.title}</Card.Body>
+      <Button href={`/categories/${categoryObj.id}`}>click me</Button>
     </Card>
   );
 }
@@ -12,6 +21,7 @@ function CategoryCard({ categoryObj }) {
 CategoryCard.propTypes = {
   categoryObj: PropTypes.shape({
     title: PropTypes.string,
+    id: PropTypes.number,
   }).isRequired,
 };
 

--- a/src/components/forms/StoryForm.js
+++ b/src/components/forms/StoryForm.js
@@ -10,7 +10,7 @@ import Select from 'react-select';
 import { useAuth } from '../../utils/context/authContext';
 import { createStory, updateStory } from '../../api/storyData';
 import targetAudienceArray from '../../utils/sample-data/targetAudienceArray.json';
-import getCategories from '../../api/categoryData';
+import { getCategories } from '../../api/categoryData';
 import getTags from '../../api/tagData';
 import { addStoryTag, removeStoryTag } from '../../api/storyTagData';
 


### PR DESCRIPTION
## Detailed Description
<!--- Explain **what** was changed and **why** -->
When on the categories page, users can now click on a category, which will navigate them to a page that renders story cards for each story associated with that category. This change enhances user experience by allowing easier access to stories based on genre.

## How to Test
<!--- Step-by-step instructions for testing your changes. -->
<!--- Include any necessary setup steps, commands to run, or test cases. -->
1.  Start the application and navigate to the categories page.
2. Click on any category listed on the page.
3. Verify that you are redirected to a new page displaying the story cards associated with that category.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change is required to improve navigation and content discovery within the app. It addresses the need for users to easily access and view stories grouped by their respective categories.

## Types of Changes
<!--- What type of changes are introduced? Put an `x` in all the boxes that apply: -->
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💡 Improvement
- [ ] ⚠️ Breaking change
- [ ] 🧹 Code cleanup
- [ ] 📖 Documentation