### PR TITLE
Tags clickable

### DIFF
--- a/src/api/categoryData.js
+++ b/src/api/categoryData.js
@@ -30,8 +30,4 @@ const getStoriesByCategory = (categoryId) =>
       .catch(reject);
   });
 
-const trash = () => {
-  console.warn('delete me');
-};
-
-export { getCategories, getStoriesByCategory, trash };
+export { getCategories, getStoriesByCategory };

--- a/src/api/tagData.js
+++ b/src/api/tagData.js
@@ -16,4 +16,18 @@ const getTags = () =>
       .catch(reject);
   });
 
-export default getTags;
+// READ Tagged stories
+const getTagStories = (tagId) =>
+  new Promise((resolve, reject) => {
+    fetch(`${endpoint}/tags/${tagId}`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })
+      .then((response) => response.json())
+      .then((data) => resolve(data.stories))
+      .catch(reject);
+  });
+
+export { getTags, getTagStories };

--- a/src/app/stories/[storyId]/page.js
+++ b/src/app/stories/[storyId]/page.js
@@ -4,11 +4,13 @@ import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { getSingleStory } from '@/api/storyData';
 import TableOfContents from '@/components/TableOfContents';
+// import { getTagStories } from '../../../api/tagData';
 
 export default function ViewStory({ params }) {
   const [storyDetails, setStoryDetails] = useState({});
 
   useEffect(() => {
+    // console.warn('!!!!!!!!', getTagStories(3));
     if (params.storyId) {
       getSingleStory(params.storyId).then((data) => setStoryDetails(data));
     }

--- a/src/app/stories/[storyId]/page.js
+++ b/src/app/stories/[storyId]/page.js
@@ -4,13 +4,11 @@ import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { getSingleStory } from '@/api/storyData';
 import TableOfContents from '@/components/TableOfContents';
-// import { getTagStories } from '../../../api/tagData';
 
 export default function ViewStory({ params }) {
   const [storyDetails, setStoryDetails] = useState({});
 
   useEffect(() => {
-    // console.warn('!!!!!!!!', getTagStories(3));
     if (params.storyId) {
       getSingleStory(params.storyId).then((data) => setStoryDetails(data));
     }
@@ -48,7 +46,9 @@ export default function ViewStory({ params }) {
               <ul className="list-inline">
                 {storyDetails.tags.map((tag) => (
                   <li key={tag.id} className="list-inline-item">
-                    <span className="badge bg-primary">{tag.name}</span>
+                    <a href={`/tagStories/${tag.id}`} className="badge bg-primary">
+                      {tag.name}
+                    </a>
                   </li>
                 ))}
               </ul>

--- a/src/app/tagStories/[tagId]/page.js
+++ b/src/app/tagStories/[tagId]/page.js
@@ -1,0 +1,36 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import StoryCard from '../../../components/StoryCard';
+import { getTagStories } from '../../../api/tagData';
+
+export default function TaggedStories({ params }) {
+  const [tagStories, setTagStories] = useState([]);
+
+  const { tagId } = params;
+
+  const getTaggedStories = () => {
+    getTagStories(tagId).then((data) => {
+      setTagStories(data);
+    });
+  };
+
+  useEffect(() => {
+    getTaggedStories();
+  }, []);
+
+  return (
+    <div className="d-flex flex-wrap justify-content-center">
+      {tagStories.map((story) => (
+        <StoryCard key={story.id} storyObj={story} onUpdate={getTaggedStories} />
+      ))}
+    </div>
+  );
+}
+
+TaggedStories.propTypes = {
+  params: PropTypes.shape({
+    tagId: PropTypes.number.isRequired,
+  }).isRequired,
+};

--- a/src/components/Category.js
+++ b/src/components/Category.js
@@ -1,15 +1,8 @@
 import PropTypes from 'prop-types';
 import { Button } from 'react-bootstrap';
 import Card from 'react-bootstrap/Card';
-// import { useRouter } from 'next/navigation';
 
 function CategoryCard({ categoryObj }) {
-  //  const router = useRouter();
-
-  // const handleCategoryClick = (categoryId) => {
-  //   router.push(`/categories/${categoryId}`);
-  // };
-
   return (
     <Card>
       <Card.Body>{categoryObj.title}</Card.Body>

--- a/src/components/forms/StoryForm.js
+++ b/src/components/forms/StoryForm.js
@@ -11,7 +11,7 @@ import { useAuth } from '../../utils/context/authContext';
 import { createStory, updateStory } from '../../api/storyData';
 import targetAudienceArray from '../../utils/sample-data/targetAudienceArray.json';
 import { getCategories } from '../../api/categoryData';
-import getTags from '../../api/tagData';
+import { getTags } from '../../api/tagData';
 import { addStoryTag, removeStoryTag } from '../../api/storyTagData';
 
 const initialState = {


### PR DESCRIPTION
## Detailed Description
<!--- Explain **what** was changed and **why** -->
Made the tags in the story's details view clickable. When a user clicks on a tag, they are taken to a page displaying all stories associated with that tag, making it easier to explore similar content.

## How to Test
<!--- Step-by-step instructions for testing your changes. -->
<!--- Include any necessary setup steps, commands to run, or test cases. -->
1.  Navigate to the story details view of any story that has tags.
2. Click on a tag displayed in the details view.
3. Verify that clicking the tag takes you to a new page where all stories with the same tag are rendered.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change is required to improve user experience by allowing easier navigation between stories with similar themes or topics. It encourages exploration of related content based on tags.

## Types of Changes
<!--- What type of changes are introduced? Put an `x` in all the boxes that apply: -->
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💡 Improvement
- [ ] ⚠️ Breaking change
- [ ] 🧹 Code cleanup
- [ ] 📖 Documentation